### PR TITLE
feat: Render.com Blueprint設定を追加

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,34 @@
+services:
+  - type: web
+    name: oogiri-app
+    env: node
+    plan: free
+    buildCommand: npm ci && npm run build
+    startCommand: npm start
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: DATABASE_URL
+        fromDatabase:
+          name: oogiri-db
+          property: connectionString
+      - key: NEXTAUTH_URL
+        value: https://oogiri-app.onrender.com
+      - key: NEXTAUTH_SECRET
+        generateValue: true
+      # BASIC認証設定は、Render.comダッシュボードで手動設定:
+      # - BASIC_AUTH_ENABLED (true/false)
+      # - BASIC_AUTH_USER
+      # - BASIC_AUTH_PASSWORD
+      # Google認証設定は、Render.comダッシュボードで手動設定:
+      # - GOOGLE_CLIENT_ID
+      # - GOOGLE_CLIENT_SECRET
+      # WebSocket設定は、Render.comダッシュボードで手動設定:
+      # - WEBSOCKET_URL (wss://oogiri-app.onrender.com)
+    healthCheckPath: /api/health
+
+databases:
+  - name: oogiri-db
+    databaseName: oogiri
+    user: oogiri_user
+    plan: free


### PR DESCRIPTION
## Summary

Render.com Blueprint (IaC) 設定を追加し、Infrastructure as Code による自動デプロイ環境を構築しました。

- render.yamlファイルを作成してRender.com対応
- PostgreSQLデータベースとWeb Service設定
- 無料プランでの試験運用対応
- セキュリティを考慮した機密情報管理

## 主な変更点

### render.yaml
- **Web Service**: Next.jsアプリケーション (無料プラン)
- **Database**: PostgreSQL (無料プラン)  
- **Environment Variables**: 自動連携設定
- **Health Check**: `/api/health` エンドポイント

### セキュリティ設定
機密情報はrender.yamlに含めず、Render.comダッシュボードで手動設定:
- `BASIC_AUTH_ENABLED`, `BASIC_AUTH_USER`, `BASIC_AUTH_PASSWORD`
- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`
- `WEBSOCKET_URL`

### 無料プラン制限
- 15分非アクティブでスリープ
- 月100GB帯域制限
- 月500分ビルド制限

## Test plan
- [ ] Render.comでのデプロイテスト
- [ ] 環境変数設定の確認
- [ ] WebSocket接続テスト
- [ ] BASIC認証動作確認
- [ ] Google認証動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)