### PR TITLE
fix: 本番環境でのNextAuth INVALID_REQUEST エラーを修正

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,7 +68,8 @@ oogiri-app/
 │   │   ├── globals.css             # グローバルスタイル
 │   │   ├── favicon.ico             # ファビコン
 │   │   ├── 📁 api/                 # API Routes
-│   │   │   ├── 📁 auth/            # NextAuth設定・401エラー
+│   │   │   ├── 📁 auth/            # NextAuth設定・本番対応
+│   │   │   │   └── [...nextauth]/  # NextAuth認証エンドポイント
 │   │   │   ├── 📁 rooms/           # ルーム管理API
 │   │   │   │   ├── route.ts        # ルーム作成・一覧
 │   │   │   │   ├── join/route.ts   # ルーム参加
@@ -83,6 +84,8 @@ oogiri-app/
 │   │   │   │       └── next-round/ # 次ラウンド
 │   │   │   └── 📁 questions/       # お題管理
 │   │   │       └── seed/           # お題データシード
+│   │   ├── 📁 actions/             # サーバーアクション
+│   │   │   └── auth.ts             # 認証関連アクション (本番対応)
 │   │   ├── 📁 auth/                # 認証ページ
 │   │   │   └── signin/             # サインインページ
 │   │   ├── 📁 rooms/               # ルーム関連ページ
@@ -96,8 +99,8 @@ oogiri-app/
 │   ├── 📁 components/              # Reactコンポーネント
 │   │   ├── 📁 auth/                # 認証関連UI
 │   │   │   ├── auth-provider.tsx   # 認証プロバイダー
-│   │   │   ├── signin-button.tsx   # サインインボタン
-│   │   │   ├── signout-button.tsx  # サインアウトボタン
+│   │   │   ├── signin-button.tsx   # サーバーアクション対応サインインボタン
+│   │   │   ├── signout-button.tsx  # サーバーアクション対応サインアウトボタン
 │   │   │   └── user-nav.tsx        # ユーザーナビゲーション
 │   │   ├── 📁 game/                # ゲーム関連UI
 │   │   │   ├── game-room.tsx       # ゲームルーム (基本版)
@@ -124,6 +127,7 @@ oogiri-app/
 │   │   ├── 📁 types/               # 型定義
 │   │   │   └── websocket.ts        # WebSocket型定義 (any型除去済み)
 │   │   ├── auth.ts                 # NextAuth設定
+│   │   ├── auth-server.ts          # NextAuth v5 サーバー設定 (本番対応)
 │   │   ├── config.ts               # 設定管理・環境変数・定数
 │   │   ├── validation.ts           # 入力検証・サニタイゼーション
 │   │   ├── logger.ts               # 構造化ログシステム
@@ -459,19 +463,54 @@ POST     /api/questions/seed            // お題データシード
 ### **NextAuth.js + Google OAuth**
 
 ```typescript
-// src/lib/auth.ts
+// src/lib/auth.ts - 認証設定
 export const authOptions: NextAuthOptions = {
-  adapter: DrizzleAdapter(db, createTable),
+  adapter: DrizzleAdapter(db),
   providers: [
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID!,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
     }),
   ],
-  session: { strategy: "jwt" },
-  pages: {
-    signIn: "/auth/signin",
+  callbacks: {
+    session: ({ session, user }) => ({
+      ...session,
+      user: {
+        ...session.user,
+        id: user.id,
+      },
+    }),
   },
+  pages: {
+    signIn: '/auth/signin',
+  },
+};
+
+// src/lib/auth-server.ts - NextAuth v5 サーバー設定
+const { handlers, auth, signIn, signOut } = NextAuth(authOptions);
+```
+
+### **サーバーアクション認証 (本番環境対応)**
+
+```typescript
+// src/app/actions/auth.ts - サーバーアクション
+'use server';
+
+export async function signInAction() {
+  await nextAuthSignIn('google', { redirectTo: '/' });
+}
+
+export async function signOutAction() {
+  await nextAuthSignOut({ redirectTo: '/' });
+}
+
+// src/components/auth/signin-button.tsx - フォームベース認証
+export function SignInButton() {
+  return (
+    <form action={signInAction}>
+      <Button type="submit">Googleでログイン</Button>
+    </form>
+  );
 }
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,8 +99,10 @@ oogiri-app/
 │   ├── 📁 components/              # Reactコンポーネント
 │   │   ├── 📁 auth/                # 認証関連UI
 │   │   │   ├── auth-provider.tsx   # 認証プロバイダー
-│   │   │   ├── signin-button.tsx   # サーバーアクション対応サインインボタン
-│   │   │   ├── signout-button.tsx  # サーバーアクション対応サインアウトボタン
+│   │   │   ├── signin-button.tsx   # 開発環境用サインインボタン
+│   │   │   ├── signout-button.tsx  # 開発環境用サインアウトボタン
+│   │   │   ├── production-signin-button.tsx # 本番環境用サーバーアクションボタン
+│   │   │   ├── adaptive-signin-button.tsx # 環境適応型サインインボタン
 │   │   │   └── user-nav.tsx        # ユーザーナビゲーション
 │   │   ├── 📁 game/                # ゲーム関連UI
 │   │   │   ├── game-room.tsx       # ゲームルーム (基本版)
@@ -127,7 +129,8 @@ oogiri-app/
 │   │   ├── 📁 types/               # 型定義
 │   │   │   └── websocket.ts        # WebSocket型定義 (any型除去済み)
 │   │   ├── auth.ts                 # NextAuth設定
-│   │   ├── auth-server.ts          # NextAuth v5 サーバー設定 (本番対応)
+│   │   ├── auth-server.ts          # NextAuth v4 サーバー設定 (本番対応)
+│   │   ├── auth-utils.ts           # 認証関連ユーティリティ関数
 │   │   ├── config.ts               # 設定管理・環境変数・定数
 │   │   ├── validation.ts           # 入力検証・サニタイゼーション
 │   │   ├── logger.ts               # 構造化ログシステム
@@ -486,31 +489,41 @@ export const authOptions: NextAuthOptions = {
   },
 };
 
-// src/lib/auth-server.ts - NextAuth v5 サーバー設定
-const { handlers, auth, signIn, signOut } = NextAuth(authOptions);
+// src/lib/auth-server.ts - NextAuth v4 サーバー設定
+const handler = NextAuth(authOptions);
+export { handler as GET, handler as POST };
 ```
 
-### **サーバーアクション認証 (本番環境対応)**
+### **環境適応型認証システム (本番環境対応)**
 
 ```typescript
-// src/app/actions/auth.ts - サーバーアクション
-'use server';
+// src/lib/auth-utils.ts - 共通ユーティリティ
+export const isProduction = (): boolean => process.env.NODE_ENV === 'production';
+export const getAuthRedirectUrl = (provider: string, callbackUrl = '/') => 
+  `/api/auth/signin/${provider}?callbackUrl=${encodeURIComponent(callbackUrl)}`;
 
-export async function signInAction() {
-  await nextAuthSignIn('google', { redirectTo: '/' });
+// src/app/actions/auth.ts - エラーハンドリング対応サーバーアクション
+export async function signInWithGoogle() {
+  try {
+    if (isProduction()) {
+      const redirectUrl = getAuthRedirectUrl('google', '/');
+      redirect(redirectUrl);
+    } else {
+      throw new Error('DEV_ENV_CLIENT_AUTH_REQUIRED');
+    }
+  } catch (error) {
+    logAuthError('signInWithGoogle', error);
+    throw new Error('Authentication failed. Please try again.');
+  }
 }
 
-export async function signOutAction() {
-  await nextAuthSignOut({ redirectTo: '/' });
-}
-
-// src/components/auth/signin-button.tsx - フォームベース認証
-export function SignInButton() {
-  return (
-    <form action={signInAction}>
-      <Button type="submit">Googleでログイン</Button>
-    </form>
-  );
+// src/components/auth/adaptive-signin-button.tsx - 環境判定
+export function AdaptiveSignInButton() {
+  if (isProduction()) {
+    return <ProductionSignInButton />; // サーバーアクション
+  } else {
+    return <SignInButton />; // クライアントサイド認証
+  }
 }
 ```
 

--- a/src/app/actions/auth.ts
+++ b/src/app/actions/auth.ts
@@ -1,24 +1,56 @@
 'use server';
 
-// NextAuth v4でのサーバーアクション対応版
-// クライアント側のsignIn/signOutをフォームから呼び出すためのブリッジ関数
+import { redirect } from 'next/navigation';
+import { 
+  isProduction, 
+  getAuthRedirectUrl, 
+  getSignOutUrl, 
+  logAuthError, 
+  logDevAuthWarning 
+} from '@/lib/auth-utils';
 
+/**
+ * 本番環境対応のGoogleサインインサーバーアクション
+ * 開発環境では適切なエラーメッセージを返し、
+ * 本番環境ではサーバーアクションによるリダイレクトを実行
+ */
 export async function signInWithGoogle() {
-  // 本番環境では直接リダイレクト、開発環境ではフォームフローを使用
-  const isProduction = process.env.NODE_ENV === 'production';
-  
-  if (isProduction) {
-    // 本番環境：直接リダイレクト（Cloud Runなどでの問題回避）
-    const { redirect } = await import('next/navigation');
-    redirect('/api/auth/signin/google?callbackUrl=/');
-  } else {
-    // 開発環境：通常のNextAuthフローを使用
-    throw new Error('Use client-side signIn for development');
+  try {
+    if (isProduction()) {
+      // 本番環境：サーバーアクションによるリダイレクト（Cloud Run対応）
+      const redirectUrl = getAuthRedirectUrl('google', '/');
+      redirect(redirectUrl);
+    } else {
+      // 開発環境：適切なメッセージでクライアント側認証を促す
+      const message = 'Development environment detected. Please use client-side signIn for local development.';
+      logDevAuthWarning(message);
+      
+      // 開発環境では例外を投げる代わりに、適切なエラー応答を返す
+      throw new Error('DEV_ENV_CLIENT_AUTH_REQUIRED');
+    }
+  } catch (error) {
+    logAuthError('signInWithGoogle', error);
+    
+    // 開発環境の場合は特定のエラーを再スロー
+    if (error instanceof Error && error.message === 'DEV_ENV_CLIENT_AUTH_REQUIRED') {
+      throw error;
+    }
+    
+    // その他のエラーの場合は汎用エラーメッセージ
+    throw new Error('Authentication failed. Please try again.');
   }
 }
 
+/**
+ * サインアウトサーバーアクション
+ * 全環境で共通の動作
+ */
 export async function signOutAction() {
-  // サインアウトは環境に関係なく直接リダイレクト
-  const { redirect } = await import('next/navigation');
-  redirect('/api/auth/signout?callbackUrl=/');
+  try {
+    const redirectUrl = getSignOutUrl('/');
+    redirect(redirectUrl);
+  } catch (error) {
+    logAuthError('signOutAction', error);
+    throw new Error('Sign out failed. Please try again.');
+  }
 }

--- a/src/app/actions/auth.ts
+++ b/src/app/actions/auth.ts
@@ -1,0 +1,24 @@
+'use server';
+
+// NextAuth v4でのサーバーアクション対応版
+// クライアント側のsignIn/signOutをフォームから呼び出すためのブリッジ関数
+
+export async function signInWithGoogle() {
+  // 本番環境では直接リダイレクト、開発環境ではフォームフローを使用
+  const isProduction = process.env.NODE_ENV === 'production';
+  
+  if (isProduction) {
+    // 本番環境：直接リダイレクト（Cloud Runなどでの問題回避）
+    const { redirect } = await import('next/navigation');
+    redirect('/api/auth/signin/google?callbackUrl=/');
+  } else {
+    // 開発環境：通常のNextAuthフローを使用
+    throw new Error('Use client-side signIn for development');
+  }
+}
+
+export async function signOutAction() {
+  // サインアウトは環境に関係なく直接リダイレクト
+  const { redirect } = await import('next/navigation');
+  redirect('/api/auth/signout?callbackUrl=/');
+}

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,3 @@
-import NextAuth from 'next-auth';
-import { authOptions } from '@/lib/auth';
+import { handlers } from '@/lib/auth-server';
 
-const handler = NextAuth(authOptions);
-
-export { handler as GET, handler as POST };
+export { handlers as GET, handlers as POST };

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,3 @@
-import { handlers } from '@/lib/auth-server';
+import { GET, POST } from '@/lib/auth-server';
 
-export { handlers as GET, handlers as POST };
+export { GET, POST };

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,4 +1,4 @@
-import { SignInButton } from '@/components/auth/signin-button';
+import { AdaptiveSignInButton } from '@/components/auth/adaptive-signin-button';
 
 export default function SignIn() {
   return (
@@ -13,7 +13,7 @@ export default function SignIn() {
           </p>
         </div>
         <div className="mt-8 space-y-6">
-          <SignInButton />
+          <AdaptiveSignInButton />
         </div>
       </div>
     </div>

--- a/src/components/auth/adaptive-signin-button.tsx
+++ b/src/components/auth/adaptive-signin-button.tsx
@@ -1,11 +1,14 @@
 import { SignInButton } from './signin-button';
 import { ProductionSignInButton } from './production-signin-button';
+import { isProduction } from '@/lib/auth-utils';
 
-// 環境に応じて適切なサインインボタンを表示
+/**
+ * 環境に応じて適切なサインインボタンを表示
+ * - 開発環境: クライアントサイド認証（next-auth/react）
+ * - 本番環境: サーバーアクション認証（Cloud Run対応）
+ */
 export function AdaptiveSignInButton() {
-  const isProduction = process.env.NODE_ENV === 'production';
-  
-  if (isProduction) {
+  if (isProduction()) {
     return <ProductionSignInButton />;
   } else {
     return <SignInButton />;

--- a/src/components/auth/adaptive-signin-button.tsx
+++ b/src/components/auth/adaptive-signin-button.tsx
@@ -1,0 +1,13 @@
+import { SignInButton } from './signin-button';
+import { ProductionSignInButton } from './production-signin-button';
+
+// 環境に応じて適切なサインインボタンを表示
+export function AdaptiveSignInButton() {
+  const isProduction = process.env.NODE_ENV === 'production';
+  
+  if (isProduction) {
+    return <ProductionSignInButton />;
+  } else {
+    return <SignInButton />;
+  }
+}

--- a/src/components/auth/production-signin-button.tsx
+++ b/src/components/auth/production-signin-button.tsx
@@ -1,0 +1,21 @@
+import { Button } from '@/components/ui/button';
+
+// 本番環境専用のサーバーアクション対応サインインボタン
+async function signInAction() {
+  'use server';
+  const { redirect } = await import('next/navigation');
+  redirect('/api/auth/signin/google?callbackUrl=/');
+}
+
+export function ProductionSignInButton() {
+  return (
+    <form action={signInAction}>
+      <Button 
+        type="submit"
+        className="w-full"
+      >
+        Googleでログイン
+      </Button>
+    </form>
+  );
+}

--- a/src/components/auth/production-signin-button.tsx
+++ b/src/components/auth/production-signin-button.tsx
@@ -1,15 +1,14 @@
 import { Button } from '@/components/ui/button';
+import { signInWithGoogle } from '@/app/actions/auth';
 
-// 本番環境専用のサーバーアクション対応サインインボタン
-async function signInAction() {
-  'use server';
-  const { redirect } = await import('next/navigation');
-  redirect('/api/auth/signin/google?callbackUrl=/');
-}
-
+/**
+ * 本番環境専用のサーバーアクション対応サインインボタン
+ * Cloud Run等でのINVALID_REQUESTエラー回避のため、
+ * フォームベースのサーバーアクションを使用
+ */
 export function ProductionSignInButton() {
   return (
-    <form action={signInAction}>
+    <form action={signInWithGoogle}>
       <Button 
         type="submit"
         className="w-full"

--- a/src/components/auth/signin-button.tsx
+++ b/src/components/auth/signin-button.tsx
@@ -4,9 +4,14 @@ import { signIn } from 'next-auth/react';
 import { Button } from '@/components/ui/button';
 
 export function SignInButton() {
+  const handleSignIn = async () => {
+    // 本番環境とローカル環境で統一した動作
+    await signIn('google', { callbackUrl: '/' });
+  };
+
   return (
     <Button 
-      onClick={() => signIn('google', { callbackUrl: '/' })}
+      onClick={handleSignIn}
       className="w-full"
     >
       Googleでログイン

--- a/src/components/auth/signout-button.tsx
+++ b/src/components/auth/signout-button.tsx
@@ -8,9 +8,13 @@ interface SignOutButtonProps {
 }
 
 export function SignOutButton({ children }: SignOutButtonProps) {
+  const handleSignOut = async () => {
+    await signOut({ callbackUrl: '/' });
+  };
+
   return (
     <Button 
-      onClick={() => signOut({ callbackUrl: '/' })}
+      onClick={handleSignOut}
       variant="outline"
     >
       {children || 'ログアウト'}

--- a/src/lib/auth-server.ts
+++ b/src/lib/auth-server.ts
@@ -1,0 +1,10 @@
+import NextAuth from 'next-auth';
+import { authOptions } from './auth';
+
+const handler = NextAuth(authOptions);
+
+// For NextAuth v4, we need to create our own signIn/signOut server actions
+export { handler as handlers };
+
+// We'll use server actions that call the NextAuth API endpoints directly
+// This is the recommended approach for NextAuth v4 in production

--- a/src/lib/auth-server.ts
+++ b/src/lib/auth-server.ts
@@ -1,10 +1,15 @@
 import NextAuth from 'next-auth';
 import { authOptions } from './auth';
 
+// NextAuth v4 ハンドラーを作成
 const handler = NextAuth(authOptions);
 
-// For NextAuth v4, we need to create our own signIn/signOut server actions
-export { handler as handlers };
+// NextAuth API ルート用のハンドラーをエクスポート
+export { handler as GET, handler as POST };
 
-// We'll use server actions that call the NextAuth API endpoints directly
-// This is the recommended approach for NextAuth v4 in production
+/**
+ * NextAuth v4対応のサーバーサイド認証設定
+ * 本番環境でのINVALID_REQUESTエラー回避のため、
+ * APIルートでの直接ハンドリングを実装
+ */
+export const authHandler = handler;

--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -1,0 +1,40 @@
+/**
+ * 認証関連のユーティリティ関数
+ */
+
+/**
+ * 現在の環境が本番環境かどうかを判定
+ */
+export const isProduction = (): boolean => {
+  return process.env.NODE_ENV === 'production';
+};
+
+/**
+ * 認証プロバイダーのリダイレクトURLを生成
+ */
+export const getAuthRedirectUrl = (provider: string, callbackUrl = '/'): string => {
+  return `/api/auth/signin/${provider}?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+};
+
+/**
+ * サインアウト用のリダイレクトURLを生成
+ */
+export const getSignOutUrl = (callbackUrl = '/'): string => {
+  return `/api/auth/signout?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+};
+
+/**
+ * 認証エラーのログ出力
+ */
+export const logAuthError = (context: string, error: unknown): void => {
+  console.error(`[Auth Error] ${context}:`, error);
+};
+
+/**
+ * 開発環境での認証警告ログ
+ */
+export const logDevAuthWarning = (message: string): void => {
+  if (!isProduction()) {
+    console.warn(`[Auth Development] ${message}`);
+  }
+};


### PR DESCRIPTION
## Summary
本番環境（Cloud Run等）でのGoogleログイン時に発生する `INVALID_REQUEST` エラーを修正しました。

## 問題の詳細
- 本番環境でのGoogleログイン時に `INVALID_REQUEST` エラーが発生
- クライアントサイドの `signIn` (next-auth/react) が本番環境で動作しない問題
- 参考記事: https://btj0.com/blog/web/next-auth-invalid_request-error/

## 解決策
### 🔧 環境適応型認証システムの実装
- **開発環境**: 従来の `next-auth/react` signIn を使用
- **本番環境**: サーバーアクション + フォームベースの認証

### 📁 新規追加ファイル
- `src/components/auth/adaptive-signin-button.tsx` - 環境判定ボタン
- `src/components/auth/production-signin-button.tsx` - 本番環境専用ボタン  
- `src/app/actions/auth.ts` - サーバーアクション
- `src/lib/auth-server.ts` - NextAuth v4ハンドラー

### 🔄 変更されたファイル
- `src/components/auth/signin-button.tsx` - 開発環境用に最適化
- `src/components/auth/signout-button.tsx` - 開発環境用に最適化
- `src/app/auth/signin/page.tsx` - アダプティブボタンを使用
- `src/app/api/auth/[...nextauth]/route.ts` - NextAuth v4対応
- `docs/ARCHITECTURE.md` - 認証システムドキュメント更新

## Test plan
- [x] ローカル環境でのログイン動作確認
- [x] ビルドテスト成功
- [x] TypeScript型チェック通過
- [ ] 本番環境でのデプロイ・動作確認

## 技術的詳細
NextAuth v4でのCloud Run対応により、クライアントサイド認証から環境適応型のサーバーアクション認証に変更。開発体験を損なわずに本番環境での問題を解決。

🤖 Generated with [Claude Code](https://claude.ai/code)