### PR TITLE
feat: トップページに開発中警告バナーを追加し、アイコンを統一

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,14 +4,33 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { UserNav } from "@/components/auth/user-nav";
 import { 
-  Theater, GamepadIcon, DoorOpen, Home as HomeIcon, Users, 
+  MessageSquare, GamepadIcon, DoorOpen, Home as HomeIcon, Users, 
   Edit3, Trophy, Zap, FileText, Vote, BarChart3, 
-  Key, Settings, Rocket, Eye
+  Key, Settings, Rocket, Eye, AlertTriangle, Database
 } from 'lucide-react';
 
 export default function Home() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-800">
+      {/* 開発中警告バナー */}
+      <div className="bg-orange-500/10 border-b border-orange-200 dark:border-orange-800">
+        <div className="container mx-auto px-4 py-3">
+          <div className="flex items-center justify-center gap-4 text-orange-800 dark:text-orange-200">
+            <AlertTriangle className="w-5 h-5" />
+            <span className="text-sm font-medium">
+              🚧 開発中のアプリケーションです
+            </span>
+            <span className="text-sm text-orange-700 dark:text-orange-300">•</span>
+            <div className="flex items-center gap-2">
+              <Database className="w-4 h-4" />
+              <span className="text-sm">
+                データベースが定期的にリセットされる可能性があります
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      
       {/* ヘッダー */}
       <header className="border-b bg-white/80 backdrop-blur-sm dark:bg-slate-900/80">
         <div className="container mx-auto px-4 py-4">
@@ -39,7 +58,7 @@ export default function Home() {
         <section className="text-center mb-16">
           <div className="max-w-3xl mx-auto">
             <Badge className="mb-4" variant="secondary">
-              <Theater className="w-4 h-4 mr-2" />
+              <MessageSquare className="w-4 h-4 mr-2" />
               リアルタイムマルチプレイヤー大喜利
             </Badge>
             <h1 className="text-5xl font-bold mb-6 bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
@@ -213,7 +232,7 @@ export default function Home() {
           <Card className="max-w-3xl mx-auto text-center bg-gradient-to-r from-blue-50 to-purple-50 dark:from-blue-950 dark:to-purple-950 border-blue-200">
             <CardContent className="pt-12 pb-12">
               <div className="w-16 h-16 mx-auto mb-6 flex items-center justify-center">
-                <Theater className="w-16 h-16 text-blue-600" />
+                <MessageSquare className="w-16 h-16 text-blue-600" />
               </div>
               <h2 className="text-3xl font-bold mb-4">今すぐ友達と大喜利バトル！</h2>
               <p className="text-xl text-muted-foreground mb-8">

--- a/src/app/rooms/page.tsx
+++ b/src/app/rooms/page.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { UserNav } from "@/components/auth/user-nav";
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { DoorOpen, Plus, Theater, Home, Users, Key } from 'lucide-react';
+import { DoorOpen, Plus, MessageSquare, Home, Users, Key } from 'lucide-react';
 
 interface Room {
   id: string;
@@ -136,7 +136,7 @@ export default function RoomsPage() {
               <CardContent className="space-y-4">
                 <div className="text-center py-8">
                   <div className="w-16 h-16 mx-auto mb-4 flex items-center justify-center">
-                    <Theater className="w-16 h-16 text-blue-600" />
+                    <MessageSquare className="w-16 h-16 text-blue-600" />
                   </div>
                   <p className="text-muted-foreground mb-4">
                     あなたがホストとなってゲームを主催します

--- a/src/components/game/game-room.tsx
+++ b/src/components/game/game-room.tsx
@@ -9,7 +9,7 @@ import { Progress } from '@/components/ui/progress';
 import { Textarea } from '@/components/ui/textarea';
 import { GameState, GameEngine, Player, Question } from '@/lib/game-logic';
 import { getRandomQuestion } from '@/lib/sample-questions';
-import { Theater, MessageCircle, Trophy, PartyPopper, Crown, Users, FileText, CheckCircle, Clock, Vote, Medal } from 'lucide-react';
+import { MessageSquare, MessageCircle, Trophy, PartyPopper, Crown, Users, FileText, CheckCircle, Clock, Vote, Medal } from 'lucide-react';
 
 interface GameRoomProps {
   roomId: string;
@@ -128,7 +128,7 @@ export function GameRoom({ roomId, currentUser }: GameRoomProps) {
               <div className="flex items-center justify-between">
                 <div>
                   <CardTitle className="flex items-center gap-3">
-                    <Theater className="w-4 h-4 inline mr-1" />
+                    <MessageSquare className="w-4 h-4 inline mr-1" />
                     ルーム: {roomId}
                     <Badge variant={getStatusColor() as 'default' | 'secondary' | 'destructive' | 'outline' | null | undefined}>
                       {getStatusDisplay()}

--- a/src/components/game/real-game-room.tsx
+++ b/src/components/game/real-game-room.tsx
@@ -9,7 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { Textarea } from '@/components/ui/textarea';
 import { GameWebSocketClient } from '@/lib/websocket-client';
-import { Theater, MessageCircle, PartyPopper, Trophy, Users, FileText, CheckCircle, Clock, Vote, Medal } from 'lucide-react';
+import { MessageSquare, MessageCircle, PartyPopper, Trophy, Users, FileText, CheckCircle, Clock, Vote, Medal } from 'lucide-react';
 import { JoinMessage, LeaveMessage, AnswerMessage, VoteMessage, ErrorMessage, GameStateMessage, QuestionMessage, ResultsMessage } from '@/lib/types/websocket';
 
 interface Player {
@@ -392,7 +392,7 @@ export function RealGameRoom({ sessionId }: RealGameRoomProps) {
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-800 flex items-center justify-center">
         <div className="text-center">
           <div className="w-12 h-12 mx-auto mb-4 flex items-center justify-center">
-            <Theater className="w-12 h-12 text-blue-600" />
+            <MessageSquare className="w-12 h-12 text-blue-600" />
           </div>
           <p className="text-xl">ゲームセッションを読み込み中...</p>
         </div>
@@ -445,7 +445,7 @@ export function RealGameRoom({ sessionId }: RealGameRoomProps) {
               <div className="flex items-center justify-between">
                 <div>
                   <CardTitle className="flex items-center gap-3">
-                    <Theater className="w-4 h-4 inline mr-1" />
+                    <MessageSquare className="w-4 h-4 inline mr-1" />
                     セッション: {sessionId.slice(0, 8)}...
                     <Badge variant={connected === true ? 'default' : connected === false ? 'destructive' : 'secondary'}>
                       {connected === true ? '接続中' : connected === false ? '切断中' : '接続試行中...'}
@@ -690,7 +690,7 @@ export function RealGameRoom({ sessionId }: RealGameRoomProps) {
                           <div className="text-right">
                             <div className="text-lg font-bold">
                               {players.length === 1 ? (
-                                <Theater className="w-4 h-4" />
+                                <MessageSquare className="w-4 h-4" />
                               ) : (
                                 `${answer.votes || 0}票`
                               )}

--- a/src/components/rooms/create-room-form.tsx
+++ b/src/components/rooms/create-room-form.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Theater, Circle } from 'lucide-react';
+import { MessageSquare, Circle } from 'lucide-react';
 
 export function CreateRoomForm() {
   const { status } = useSession();
@@ -78,7 +78,7 @@ export function CreateRoomForm() {
           <CardContent className="flex items-center justify-center py-8">
             <div className="text-center">
               <div className="w-12 h-12 mx-auto mb-4 flex items-center justify-center">
-                <Theater className="w-12 h-12 text-blue-600" />
+                <MessageSquare className="w-12 h-12 text-blue-600" />
               </div>
               <p>認証状態を確認中...</p>
             </div>

--- a/src/components/rooms/room-detail.tsx
+++ b/src/components/rooms/room-detail.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import { Theater } from 'lucide-react';
+import { MessageSquare } from 'lucide-react';
 
 interface Room {
   id: string;
@@ -102,7 +102,7 @@ export function RoomDetail({ roomId }: RoomDetailProps) {
           <CardContent className="flex items-center justify-center py-8">
             <div className="text-center">
               <div className="w-12 h-12 mx-auto mb-4 flex items-center justify-center">
-                <Theater className="w-12 h-12 text-blue-600" />
+                <MessageSquare className="w-12 h-12 text-blue-600" />
               </div>
               <p>ルーム情報を読み込み中...</p>
             </div>


### PR DESCRIPTION
## Summary
- トップページに開発中である旨とデータベースリセットの警告バナーを追加
- TheaterアイコンをMessageSquareに統一してUIの一貫性を向上
- オレンジ色の警告バナーで注意を引くデザインを採用

## Test plan
- [ ] トップページにアクセスして警告バナーが表示されることを確認
- [ ] 開発中の旨が明確に記載されていることを確認
- [ ] データベースリセットの警告が適切に表示されることを確認
- [ ] 各ページのアイコンが統一されていることを確認
- [ ] ダークモードでも適切に表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)